### PR TITLE
Rearchitect for multi-language, make proto native

### DIFF
--- a/pazel/BUILD
+++ b/pazel/BUILD
@@ -21,16 +21,24 @@ py_binary(
 py_library(
     name = "bazel_rules",
     srcs = ["bazel_rules.py"],
-    deps = [],
+)
+
+py_test(
+    name = "bazel_rules_test",
+    srcs = ["bazel_rules_test.py"],
+    size = "small",
+    deps = [":bazel_rules"],
 )
 
 py_library(
     name = "generate_rule",
     srcs = ["generate_rule.py"],
     deps = [
-        ":bazel_rules",
+        "//pazel/languages/py:py_deps",
+        "//pazel/languages/py:py_rules",
+        "//pazel/languages/proto:proto_deps",
+        "//pazel/languages/proto:proto_rules",
         ":parse_build",
-        ":parse_imports",
     ],
 )
 
@@ -49,12 +57,6 @@ py_library(
 py_library(
     name = "parse_build",
     srcs = ["parse_build.py"],
-    deps = [":helpers"],
-)
-
-py_library(
-    name = "parse_imports",
-    srcs = ["parse_imports.py"],
     deps = [":helpers"],
 )
 

--- a/pazel/bazel_rules.py
+++ b/pazel/bazel_rules.py
@@ -1,36 +1,4 @@
-"""Classes for identifying Bazel rule type of a script and generating new rules to BUILD files."""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import os
 import re
-
-# These templates will be filled and used to generate BUILD files.
-# Note that both 'data' and 'deps' can be empty in which case they are left out from the rules.
-PY_BINARY_TEMPLATE = """py_binary(
-    name = "{name}",
-    srcs = ["{name}.py"],
-    {data}
-    {deps}
-)"""
-
-PY_LIBRARY_TEMPLATE = """py_library(
-    name = "{name}",
-    srcs = ["{name}.py"],
-    {data}
-    {deps}
-)"""
-
-PY_TEST_TEMPLATE = """py_test(
-    name = "{name}",
-    srcs = ["{name}.py"],
-    size = "{size}",
-    {data}
-    {deps}
-)"""
-
 
 class BazelRule(object):
     """Base class defining the interface for parsing Bazel rules.
@@ -42,13 +10,14 @@ class BazelRule(object):
     is_test_rule = None
     template = None
     rule_identifier = None
+    replaces_rules = []
 
     @staticmethod
-    def applies_to(script_name, script_source, script_extension):
+    def applies_to(script_name, script_source):
         """Check whether this rule applies to a given script.
 
         Args:
-            script_name (str): Name of a Python script without the .py suffix.
+            script_name (str): Name of a Python script without the file extension suffix.
             script_source (str): Source code of the script.
 
         Returns:
@@ -77,142 +46,3 @@ class BazelRule(object):
     def get_load_statement():
         """If the rule requires a special 'load' statement, return it, otherwise return None."""
         return None
-
-
-class PyBinaryRule(BazelRule):
-    """Class for representing Bazel-native py_binary."""
-
-    # Required class variables.
-    is_test_rule = False    # Is this a test rule?
-    template = PY_BINARY_TEMPLATE   # Filled version of this will be written to the BUILD file.
-    rule_identifier = 'py_binary'   # The name of the rule.
-
-    @staticmethod
-    def applies_to(script_name, script_source, script_extension):
-        """Check whether this rule applies to a given script.
-
-        Args:
-            script_name (str): Name of a Python script without the .py suffix.
-            script_source (str): Source code of the script.
-
-        Returns:
-            applies (bool): Whether this Bazel rule can be used to represent the script.
-        """
-        # Check if there is indentation level 0 code that launches a function.
-        entrypoints = re.findall('\nif\s*__name__\s*==\s*["\']__main__["\']\s*:', script_source)
-        entrypoints += re.findall('\n\S+\([\S+]?\)', script_source)
-
-        # Rule out tests using unittest.
-        is_test = PyTestRule.applies_to(script_name, script_source, script_extension)
-
-        applies = len(entrypoints) > 0 and not is_test
-
-        return applies
-
-
-class PyLibraryRule(BazelRule):
-    """Class for representing Bazel-native py_library."""
-
-    # Required class variables.
-    is_test_rule = False    # Is this a test rule?
-    template = PY_LIBRARY_TEMPLATE  # Filled version of this will be written to the BUILD file.
-    rule_identifier = 'py_library'  # The name of the rule.
-
-    @staticmethod
-    def applies_to(script_name, script_source, script_extension):
-        """Check whether this rule applies to a given script.
-
-        Args:
-            script_name (str): Name of a Python script without the .py suffix.
-            script_source (str): Source code of the script.
-
-        Returns:
-            applies (bool): Whether this Bazel rule can be used to represent the script.
-        """
-        is_test = PyTestRule.applies_to(script_name, script_source, script_extension)
-        is_binary = PyBinaryRule.applies_to(script_name, script_source, script_extension)
-
-        applies = not (is_test or is_binary)
-
-        return applies
-
-
-class PyTestRule(BazelRule):
-    """Class for representing Bazel-native py_test."""
-
-    # Required class variables.
-    is_test_rule = True     # Is this a test rule?
-    template = PY_TEST_TEMPLATE     # Filled version of this will be written to the BUILD file.
-    rule_identifier = 'py_test'     # The name of the rule.
-
-    @staticmethod
-    def applies_to(script_name, script_source, script_extension):
-        """Check whether this rule applies to a given script.
-
-        Args:
-            script_name (str): Name of a Python script without the .py suffix.
-            script_source (str): Source code of the script.
-
-        Returns:
-            applies (bool): Whether this Bazel rule can be used to represent the script.
-        """
-        imports_unittest = len(re.findall('import unittest', script_source)) > 0 or \
-            len(re.findall('from unittest', script_source)) > 0
-        uses_unittest = len(re.findall('unittest.TestCase', script_source)) > 0 or \
-            len(re.findall('TestCase', script_source)) > 0
-        test_filename = script_name.startswith('test_') or script_name.endswith('_test')
-
-        applies = test_filename and imports_unittest and uses_unittest
-
-        return applies
-
-
-def get_native_bazel_rules():
-    """Return a copy of the pazel-native classes implementing BazelRule."""
-    return [PyBinaryRule, PyLibraryRule, PyTestRule]    # No custom classes here.
-
-
-def infer_bazel_rule_type(script_path, script_source, custom_rules):
-    """Infer the Bazel rule type given the path to the script and its source code.
-
-    Args:
-        script_path (str): Path to a Python script.
-        script_source (str): Source code of the Python script.
-        custom_rules (list of BazelRule classes): User-defined classes implementing BazelRule.
-
-    Returns:
-        bazel_rule_type (BazelRule): Rule object representing the type of the Python script.
-
-    Raises:
-        RuntimeError: If zero or more than one Bazel rule is found for the current script.
-    """
-    script_basename = os.path.basename(script_path)
-    script_extension_index = script_basename.rfind('.')
-    script_name = script_basename[:script_extension_index]
-    script_extension = script_basename[script_extension_index:]
-
-    bazel_rule_types = []
-
-    native_rules = get_native_bazel_rules()
-    registered_rules = native_rules + custom_rules
-
-    for bazel_rule in registered_rules:
-        if bazel_rule.applies_to(script_name, script_source, script_extension):
-            bazel_rule_types.append(bazel_rule)
-
-    if not bazel_rule_types:
-        raise RuntimeError("No suitable Bazel rule type found for %s." % script_path)
-    elif len(bazel_rule_types) > 1:
-        # If the script is recognized by pazel native rule(s) and one exactly custom rule, then use
-        # the custom rule. This is because the pazel native rules may generate false positives.
-        is_custom = [rule not in native_rules for rule in bazel_rule_types]
-        one_custom = sum(is_custom) == 1
-
-        if one_custom:
-            custom_bazel_rule_idx = is_custom.index(True)
-            return bazel_rule_types[custom_bazel_rule_idx]
-        else:
-            raise RuntimeError("Multiple Bazel rule types (%s) found for %s."
-                               % (bazel_rule_types, script_path))
-
-    return bazel_rule_types[0]

--- a/pazel/bazel_rules_test.py
+++ b/pazel/bazel_rules_test.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pazel.bazel_rules import BazelRule
+
+class TestBazelRule(unittest.TestCase):
+    """Test BazelRule base class."""
+
+    def test_applies_to(self):
+        """Test BazelRule.applies_to."""
+        with self.assertRaises(NotImplementedError):
+            BazelRule.applies_to('script_name', 'script_source')
+
+    def test_find_existing(self):
+        """Test finding an existing Bazel rule in a BUILD source."""
+        build_source = """
+py_test(
+    name = "test_bazel_rules",
+    srcs = ["test_bazel_rules.py"],
+    size = "small",
+    deps = ["//pazel:bazel_rules"],
+)"""
+        self.assertIsNotNone(BazelRule.find_existing(build_source, 'test_bazel_rules.py'))
+        self.assertIsNone(BazelRule.find_existing(build_source, 'missing.py'))
+
+    def test_get_load_statement(self):
+        """Test BazelRule.get_load_statement."""
+        self.assertIsNone(BazelRule.get_load_statement())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pazel/helpers.py
+++ b/pazel/helpers.py
@@ -93,23 +93,6 @@ def is_ignored(script_path, ignored_rules):
 
     return ignored
 
-
-def is_python_file(path):
-    """Check whether the file in the given path is a Python file.
-
-    Args:
-        path (str): Path to a file.
-
-    Returns:
-        valid (bool): The file in path is a Python file.
-    """
-    valid = False
-
-    if os.path.isfile(path) and path.endswith('.py'):
-        valid = True
-
-    return valid
-
 def has_extension(path, extensions):
     """Check whether the file is a file of the given types.
 

--- a/pazel/languages/proto/BUILD
+++ b/pazel/languages/proto/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "proto_deps",
+    srcs = ["proto_deps.py"],
+    deps = ["//pazel:helpers"],
+)
+
+py_test(
+    name = "proto_deps_test",
+    srcs = ["proto_deps_test.py"],
+    size = "small",
+    deps = [":proto_deps"],
+)
+
+py_library(
+    name = "proto_rules",
+    srcs = ["proto_rules.py"],
+    deps = [
+        "//pazel:bazel_rules",
+    ],
+)
+
+py_test(
+    name = "proto_rules_test",
+    srcs = ["proto_rules_test.py"],
+    size = "small",
+    deps = [
+        ":proto_rules",
+        "//pazel:generate_rule",
+    ],
+)

--- a/pazel/languages/proto/proto_deps.py
+++ b/pazel/languages/proto/proto_deps.py
@@ -1,0 +1,58 @@
+"""Parse imports in Proto files and infer what is being imported."""
+
+import re
+
+
+def get_imports(script_source):
+    """Parse imported packages.
+
+    Args:
+        script_source (str): The source code of a Proto definition.
+
+    Returns:
+        packages (list of tuple): List of (package name, None) tuples.
+        from_imports (list of tuple): List of (package/module name, some object) tuples.
+    """
+    packages = []
+    from_imports = []
+
+    # TODO(gobeil): Ignore imports on commented lines.
+    import_matches = re.findall('(.*)import "(.*)\.proto"', script_source, re.MULTILINE)
+    for pre_match, import_match in import_matches:
+        # Ignore commented lines
+        if '//' in pre_match:
+            continue
+        # Convert to dot notation with "_proto" postfix convention.
+        components = import_match.split('/')
+        from_imports.append(('.'.join(components[:-1]), components[-1] + '_proto'))
+
+    return packages, from_imports
+
+def infer_import_type(all_imports, project_root, contains_pre_installed_packages, custom_rules):
+    packages = []
+    modules = []
+
+    for base, unknown in all_imports:
+        # TODO(gobeil): Abstract this out to share with python language copy as boilerplate.
+        custom_rule_matches = False
+        for inference_rule in custom_rules:
+            new_packages, new_modules = inference_rule.holds(project_root, base, unknown)
+
+            # If the rule holds, then add to the list of packages and/or modules.
+            if new_packages is not None:
+                packages.extend(new_packages)
+
+            if new_modules is not None:
+                modules.extend(new_modules)
+
+            if new_packages is not None or new_modules is not None:
+                custom_rule_matches = True  # Only allow one match for custom rules.
+                break
+
+        if custom_rule_matches:
+            continue
+
+        dotted_path = base + '.%s' % unknown
+        modules.append(dotted_path)
+
+    return set(packages), set(modules)

--- a/pazel/languages/proto/proto_deps_test.py
+++ b/pazel/languages/proto/proto_deps_test.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 
 import unittest
 
-from pazel.parse_imports import get_imports
+from pazel.languages.proto.proto_deps import get_imports
 
 
 class TestParseImports(unittest.TestCase):
@@ -15,17 +15,21 @@ class TestParseImports(unittest.TestCase):
     def test_get_imports(self):
         """Test parse_enclosed_expression."""
         script_source = """
-import ast
-from ast import parse
-from foo import bar as abc
-from asd import \
-    wasd
+import "google/protobuf/duration.proto";
+import "foo/public/proto/bar.proto";
+
+message MyMessage {
+    google.protobuf.Duration duration = 1;
+    foo.Bar bar = 2;
+}
 """
 
         packages, from_imports = get_imports(script_source)
 
-        expected_packages = [('ast', None)]
-        expected_from_imports = [('ast', 'parse'), ('foo', 'bar'), ('asd', 'wasd')]
+        expected_packages = []
+        expected_from_imports = [
+            ('google.protobuf', 'duration_proto'),
+            ('foo.public.proto', 'bar_proto')]
 
         self.assertEqual(packages, expected_packages)
         self.assertEqual(from_imports, expected_from_imports)

--- a/pazel/languages/proto/proto_rules.py
+++ b/pazel/languages/proto/proto_rules.py
@@ -1,0 +1,54 @@
+"""Classes for identifying Bazel rule type of a Protobuffer definition and generating new rules to BUILD files."""
+
+from pazel.bazel_rules import BazelRule
+
+
+# These templates will be filled and used to generate BUILD files.
+# Note that both 'data' and 'deps' can be empty in which case they are left out from the rules.
+PROTO_LIBRARY_TEMPLATE = """proto_library(
+    name = "{name}_proto",
+    srcs = ["{name}.proto"],
+    {data}
+    {deps}
+)
+"""
+
+PY_PROTO_LIBRARY_TEMPLATE = """
+py_proto_library(
+    name = "{name}_py_pb2",
+    deps = [":{name}_proto"],
+)
+"""
+
+class ProtoLibraryRule(BazelRule):
+    is_test_rule = False
+    template = PROTO_LIBRARY_TEMPLATE
+    rule_identifier = 'proto_library'
+
+    @staticmethod
+    def applies_to(script_name, script_source):
+        # TODO(gobeil): Scan source for proto syntax statement.
+        return True
+
+    @staticmethod
+    def get_load_statement():
+        return 'load("@rules_proto//proto:defs.bzl", "proto_library")'
+
+class PyProtoLibraryRule(BazelRule):
+    is_test_rule = False
+    template = PY_PROTO_LIBRARY_TEMPLATE
+    rule_identifier = 'py_proto_library'
+
+    @staticmethod
+    def applies_to(script_name, script_source):
+        # TODO(gobeil): Scan source for proto syntax statement.
+        # TODO(gobeil): Scan source for python generation annotation?
+        return True
+
+    @staticmethod
+    def get_load_statement():
+        return 'load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")'
+
+def get_bazel_rules():
+    """Return a copy of the pazel-native classes implementing BazelRule."""
+    return [ProtoLibraryRule, PyProtoLibraryRule]

--- a/pazel/languages/proto/proto_rules_test.py
+++ b/pazel/languages/proto/proto_rules_test.py
@@ -1,0 +1,38 @@
+
+import unittest
+
+from pazel.generate_rule import infer_bazel_rule_types
+from pazel.languages.proto.proto_rules import ProtoLibraryRule
+from pazel.languages.proto.proto_rules import PyProtoLibraryRule
+
+proto_file_src = """
+syntax = "proto3";
+
+package com.testing;
+
+message MyProto {
+  string text = 1;
+}
+"""
+
+class TestProtoLibraryRule(unittest.TestCase):
+    """Test ProtoLibraryRule."""
+
+    def test_applies_to(self):
+        """Test ProtoLibraryRule.applies_to for different script sources."""
+        self.assertEqual(ProtoLibraryRule.applies_to("my.proto", proto_file_src), True)
+        self.assertEqual(PyProtoLibraryRule.applies_to("my.proto", proto_file_src), True)
+
+class TestBazelRuleInference(unittest.TestCase):
+    """Test inferring the Bazel rule type of a script."""
+
+    def test_infer_bazel_rule_types(self):
+        """Test inferring the Bazel rule type."""
+        custom_rules = []
+
+        self.assertEqual(
+            infer_bazel_rule_types("my.proto", proto_file_src, custom_rules),
+            [ProtoLibraryRule, PyProtoLibraryRule])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pazel/languages/py/BUILD
+++ b/pazel/languages/py/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "py_deps",
+    srcs = ["py_deps.py"],
+    deps = ["//pazel:helpers"],
+)
+
+py_test(
+    name = "py_deps_test",
+    srcs = ["py_deps_test.py"],
+    size = "small",
+    deps = [":py_deps"],
+)
+
+py_library(
+    name = "py_rules",
+    srcs = ["py_rules.py"],
+    deps = [
+        "//pazel:bazel_rules",
+    ],
+)
+
+py_test(
+    name = "py_rules_test",
+    srcs = ["py_rules_test.py"],
+    size = "small",
+    deps = [
+        ":py_rules",
+        "//pazel:generate_rule",
+    ],
+)

--- a/pazel/languages/py/py_deps.py
+++ b/pazel/languages/py/py_deps.py
@@ -32,7 +32,7 @@ def get_imports(script_source):
             module = node.module
 
             for name in node.names:
-                from_imports.append((module, name.name))
+                from_imports.append((module, translate_protobuf_names(name.name)))
         # Parse expressions of the form "import X".
         elif isinstance(node, ast.Import):
             for package in node.names:
@@ -40,6 +40,12 @@ def get_imports(script_source):
 
     return packages, from_imports
 
+# TODO(gobeil): Generalize this as a contribution from the proto language module.
+def translate_protobuf_names(name):
+    """Translates protocol buffer dependencies to their matching python generated code."""
+    if name.endswith('_pb2') or name.endswith('_pb2_grpc'):
+        return name.replace('_pb2', '_py_pb2')
+    return name
 
 def infer_import_type(all_imports, project_root, contains_pre_installed_packages, custom_rules):
     """Infer what is being imported.

--- a/pazel/languages/py/py_deps_test.py
+++ b/pazel/languages/py/py_deps_test.py
@@ -1,0 +1,35 @@
+"""Test parsing imports from a Python file."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from pazel.languages.py.py_deps import get_imports
+
+
+class TestParseImports(unittest.TestCase):
+    """Test helper functions."""
+
+    def test_get_imports(self):
+        """Test parse_enclosed_expression."""
+        script_source = """
+import ast
+from ast import parse
+from foo import bar as abc
+from asd import \
+    wasd
+"""
+
+        packages, from_imports = get_imports(script_source)
+
+        expected_packages = [('ast', None)]
+        expected_from_imports = [('ast', 'parse'), ('foo', 'bar'), ('asd', 'wasd')]
+
+        self.assertEqual(packages, expected_packages)
+        self.assertEqual(from_imports, expected_from_imports)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pazel/languages/py/py_rules.py
+++ b/pazel/languages/py/py_rules.py
@@ -1,0 +1,127 @@
+"""Classes for identifying Bazel rule type of a Python script and generating new rules to BUILD files."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import re
+
+from pazel.bazel_rules import BazelRule
+
+
+# These templates will be filled and used to generate BUILD files.
+# Note that both 'data' and 'deps' can be empty in which case they are left out from the rules.
+PY_BINARY_TEMPLATE = """py_binary(
+    name = "{name}",
+    srcs = ["{name}.py"],
+    {data}
+    {deps}
+)"""
+
+PY_LIBRARY_TEMPLATE = """py_library(
+    name = "{name}",
+    srcs = ["{name}.py"],
+    {data}
+    {deps}
+)"""
+
+PY_TEST_TEMPLATE = """py_test(
+    name = "{name}",
+    srcs = ["{name}.py"],
+    size = "{size}",
+    {data}
+    {deps}
+)"""
+
+class PyBinaryRule(BazelRule):
+    """Class for representing Bazel-native py_binary."""
+
+    # Required class variables.
+    is_test_rule = False    # Is this a test rule?
+    template = PY_BINARY_TEMPLATE   # Filled version of this will be written to the BUILD file.
+    rule_identifier = 'py_binary'   # The name of the rule.
+
+    @staticmethod
+    def applies_to(script_name, script_source):
+        """Check whether this rule applies to a given script.
+
+        Args:
+            script_name (str): Name of a Python script without the .py suffix.
+            script_source (str): Source code of the script.
+
+        Returns:
+            applies (bool): Whether this Bazel rule can be used to represent the script.
+        """
+        # Check if there is indentation level 0 code that launches a function.
+        entrypoints = re.findall('\nif\s*__name__\s*==\s*["\']__main__["\']\s*:', script_source)
+        entrypoints += re.findall('\n\S+\([\S+]?\)', script_source)
+
+        # Rule out tests using unittest.
+        is_test = PyTestRule.applies_to(script_name, script_source)
+
+        applies = len(entrypoints) > 0 and not is_test
+
+        return applies
+
+
+class PyLibraryRule(BazelRule):
+    """Class for representing Bazel-native py_library."""
+
+    # Required class variables.
+    is_test_rule = False    # Is this a test rule?
+    template = PY_LIBRARY_TEMPLATE  # Filled version of this will be written to the BUILD file.
+    rule_identifier = 'py_library'  # The name of the rule.
+
+    @staticmethod
+    def applies_to(script_name, script_source):
+        """Check whether this rule applies to a given script.
+
+        Args:
+            script_name (str): Name of a Python script without the .py suffix.
+            script_source (str): Source code of the script.
+
+        Returns:
+            applies (bool): Whether this Bazel rule can be used to represent the script.
+        """
+        is_test = PyTestRule.applies_to(script_name, script_source)
+        is_binary = PyBinaryRule.applies_to(script_name, script_source)
+
+        applies = not (is_test or is_binary)
+
+        return applies
+
+
+class PyTestRule(BazelRule):
+    """Class for representing Bazel-native py_test."""
+
+    # Required class variables.
+    is_test_rule = True     # Is this a test rule?
+    template = PY_TEST_TEMPLATE     # Filled version of this will be written to the BUILD file.
+    rule_identifier = 'py_test'     # The name of the rule.
+
+    @staticmethod
+    def applies_to(script_name, script_source):
+        """Check whether this rule applies to a given script.
+
+        Args:
+            script_name (str): Name of a Python script without the .py suffix.
+            script_source (str): Source code of the script.
+
+        Returns:
+            applies (bool): Whether this Bazel rule can be used to represent the script.
+        """
+        imports_unittest = len(re.findall('import unittest', script_source)) > 0 or \
+            len(re.findall('from unittest', script_source)) > 0
+        uses_unittest = len(re.findall('unittest.TestCase', script_source)) > 0 or \
+            len(re.findall('TestCase', script_source)) > 0
+        test_filename = script_name.startswith('test_') or script_name.endswith('_test')
+
+        applies = test_filename and imports_unittest and uses_unittest
+
+        return applies
+
+
+def get_bazel_rules():
+    """Return a copy of the pazel-native classes implementing BazelRule."""
+    return [PyBinaryRule, PyLibraryRule, PyTestRule]    # No custom classes here.

--- a/pazel/tests/BUILD
+++ b/pazel/tests/BUILD
@@ -7,13 +7,6 @@ py_library(
 )
 
 py_test(
-    name = "test_bazel_rules",
-    srcs = ["test_bazel_rules.py"],
-    size = "small",
-    deps = ["//pazel:bazel_rules"],
-)
-
-py_test(
     name = "test_generate_rule",
     srcs = ["test_generate_rule.py"],
     size = "small",
@@ -25,13 +18,6 @@ py_test(
     srcs = ["test_helpers.py"],
     size = "small",
     deps = ["//pazel:helpers"],
-)
-
-py_test(
-    name = "test_parse_imports",
-    srcs = ["test_parse_imports.py"],
-    size = "small",
-    deps = ["//pazel:parse_imports"],
 )
 
 py_test(

--- a/sample_app/.pazelrc
+++ b/sample_app/.pazelrc
@@ -34,6 +34,7 @@ class PyDoctestRule(BazelRule):
     is_test_rule = True     # Is this a test rule?
     template = PY_DOCTEST_TEMPLATE  # Filled version of this will be written to the BUILD file.
     rule_identifier = 'py_doctest'  # The name of the rule.
+    replaces_rules = ['py_binary']
 
     @staticmethod
     def applies_to(script_name, script_source):

--- a/sample_app/foo/BUILD
+++ b/sample_app/foo/BUILD
@@ -1,6 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@my_deps//:requirements.bzl", "requirement")
+load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # pazel-ignore
 load("//:custom_rules.bzl", "custom_rule")
@@ -35,6 +37,26 @@ py_library(
     name = "bar6",
     srcs = ["bar6.py"],
     deps = ["//xyz:abc1"],
+)
+
+proto_library(
+    name = "baz_proto",
+    srcs = ["baz.proto"],
+    deps = [
+        "//com/abc/protobuf:share_proto",
+        "//foo:zap_proto",
+    ],
+)
+
+py_proto_library(
+    name = "baz_py_pb2",
+    deps = [":baz_proto"],
+)
+
+py_library(
+    name = "baz",
+    srcs = ["baz.py"],
+    deps = [requirement("foo")],
 )
 
 py_library(

--- a/sample_app/foo/baz.proto
+++ b/sample_app/foo/baz.proto
@@ -1,0 +1,9 @@
+package foo;
+
+import "foo/zap.proto";
+import "com/abc/protobuf/share.proto";
+
+message Baz {
+    foot.Zap zap = 1;
+    abc.Share = 2;
+}

--- a/sample_app/foo/baz.py
+++ b/sample_app/foo/baz.py
@@ -1,0 +1,2 @@
+from foo import baz_pb2
+from foo import baz_pb2_grpc

--- a/sample_app/xyz/BUILD
+++ b/sample_app/xyz/BUILD
@@ -5,7 +5,7 @@ py_binary(
     srcs = ["abc1.py"],
     deps = [
         "//foo:__init__",
-        "//foo:foo",
+        "//foo",
     ],
 )
 


### PR DESCRIPTION
- refactored hard-coded .py code into separate language packages, starting with `.py` and `.proto`
- moved `.proto` support that I was contributing from an extension into the core code
- added support for returning multiple rules per source file (e.g. `proto_library` and `py_proto_library`)
  - the single-rule limitation was being used to create a crude hierarchy that allowed custom rules to hide built-in rules (e.g. `py_doctest` hiding `py_binary` in their sample app, so replaced with a more flexible `replaces_rules = [...]` extension mechanism
- eliminated the distinction between native and contributed rules, so built in rules can contribute load() statements, which is more common now as built-in rules are being pushed out of bazel core into places like `@rules_proto`
- got all the tests running clean (including equivalent tests for the new `.proto` code)